### PR TITLE
Add DescentMethods.CholBFGS to main

### DIFF
--- a/src/DescentMethods.jl
+++ b/src/DescentMethods.jl
@@ -9,6 +9,7 @@ include("grad_descent.jl")
 include("rate_descent.jl")
 include("hypergradient.jl")
 include("quasinewton.jl")
+include("chol_bfgs.jl")
 include("optimize.jl")
 include("conjgrad.jl")
 

--- a/src/chol_bfgs.jl
+++ b/src/chol_bfgs.jl
@@ -1,0 +1,176 @@
+export CholBFGS
+"""
+    CholBFGS
+Quasi-Newton descent method.
+"""
+mutable struct CholBFGS{T<:AbstractFloat,
+                        V<:AbstractVector{T},
+                        C<:Cholesky{T}} <: CoreMethod
+    hess::C
+    x::V
+    g::V
+    xpre::V
+    gpre::V
+    d::V
+    xdiff::V
+    gdiff::V
+    y::T
+end
+
+@inline gradientvec(M::CholBFGS) = M.g
+@inline argumentvec(M::CholBFGS) = M.x
+@inline step_origin(M::CholBFGS) = M.xpre
+
+
+function CholBFGS(x::AbstractVector{T}) where {T}
+    F = float(T)
+    n = length(x)
+    m = similar(x, F, (n, n))
+    for j in 1:n, i in 1:n
+        m[i,j] = (i == j)
+    end
+    cm = cholesky!(m)
+    bfgs = CholBFGS(cm,
+                similar(x, F),
+                similar(x, F),
+                similar(x, F),
+                similar(x, F),
+                similar(x, F),
+                similar(x, F),
+                similar(x, F),
+                zero(T)
+               )
+    return bfgs
+end
+
+function init!(M::CholBFGS{T}, optfn!, x0; 
+               reset, constrain_step = infstep) where {T}
+    optfn!(x0, zero(T), x0)
+    if reset > 0
+        M.xpre, M.x = M.x, M.xpre
+        M.gpre, M.g = M.g, M.gpre
+        map!(-, M.d, M.gpre)
+        lmul!(reset, M.d)
+        αmax = constrain_step(M.xpre, M.d)
+        α = strong_backtracking!(optfn!, M.xpre, M.d, M.y, M.gpre, αmax = αmax, β = one(T)/100, σ = convert(T, 0.1))
+        map!(-, M.xdiff, M.x, M.xpre)
+        map!(-, M.gdiff, M.g, M.gpre)
+
+        scale = dot(M.gdiff, M.gdiff) / dot(M.xdiff, M.gdiff)
+        H = M.hess.factors
+        nr, nc = size(H)
+        for j in 1:nc, i in 1:nr
+            H[i, j] = (i == j) * sqrt(abs(scale)) #sqrt(abs(M.gdiff[i] / M.xdiff[j]))
+        end
+    end
+    return
+end
+
+@inline function reset!(M::CholBFGS)
+    H = M.hess.factors
+    nr, nc = size(H)
+    for j in 1:nc, i in 1:nr
+        H[i, j] = (i == j)
+    end
+    return
+end
+
+function reset!(M::CholBFGS, x0, scale::Real=1)
+    copy!(M.x, x0)
+    H = M.hess.factors
+    nr, nc = size(H)
+    for j in 1:nc, i in 1:nr
+        # update consistent with BFGS
+        H[i, j] = (i == j) / sqrt(scale)
+    end
+    return
+end
+
+@inline function callfn!(M::CholBFGS, fdf, x, α, d)
+    __update_arg!(M, x, α, d)
+    y, g = fdf(M.x, M.g)
+    __update_grad!(M, g)
+    M.y = y
+    return y, g
+end
+
+function __descent_dir!(M::CholBFGS)
+    ldiv!(M.d, M.hess, M.gpre)
+    lmul!(-1, M.d)
+    return M.d
+end
+
+function step!(M::CholBFGS, optfn!; constrain_step = infstep)
+    #=
+    argument and gradient from the end of the last
+    iteration are stored into `xpre` and `gpre`
+    =#
+    M.gpre, M.g = M.g, M.gpre
+    M.xpre, M.x = M.x, M.xpre
+
+    x, xpre, g, gpre, H = M.x, M.xpre, M.g, M.gpre, M.hess
+    d = __descent_dir!(M)
+    maxstep = constrain_step(xpre, d)
+    α = strong_backtracking!(optfn!, xpre, d, M.y, gpre, αmax = maxstep, β = 0.01, σ = 0.9)
+    if α > 0
+        #=
+        BFGS update:
+                 Hδδ'H    γγ'
+        H <- H - ------ + ---
+                  δ'Hδ    δ'γ
+        =#
+        δ, γ = M.xdiff, M.gdiff
+        γ .= g .- gpre
+        δ .= x .- xpre
+
+        #=
+        H = H.U' * H.U
+        d <- H.U * δ
+        δ'Hδ = d ⋅ d
+        =#
+        mul!(d, H.U, δ)
+        d1 = dot(d, d)
+        d2 = dot(δ, γ)
+        # δ <- H.U' * H.U * δ = H * δ
+        mul!(δ, H.U', d)
+        rdiv!(δ, sqrt(d1))
+        rdiv!(γ, sqrt(d2))
+        lowrankupdate!(H, γ)
+        lowrankdowndate!(H, δ)
+    else
+        fill!(M.xdiff, 0)
+    end
+    return α
+end
+
+@inline function __update_arg!(M::CholBFGS, x, α, d)
+    map!(M.x, d, x) do a, b
+        muladd(α, a, b)
+    end
+    return
+end
+
+@inline function __update_arg!(M::CholBFGS, x)
+    if x !== M.x
+        copy!(M.x, x)
+    end
+    return
+end
+
+@inline function __update_grad!(M::CholBFGS, g)
+    if M.g !== g
+        copy!(M.g, g)
+    end
+    return
+end
+
+function stopcond(M::CholBFGS{T}) where {T}
+    rtol_x = 16 * eps(T)
+    xdiff, xpre = M.xdiff, M.xpre
+    for i in eachindex(xdiff, xpre)
+        if abs(xdiff[i]) > rtol_x * abs(xpre[i])
+            return false
+        end
+    end
+    return true
+end

--- a/src/chol_bfgs.jl
+++ b/src/chol_bfgs.jl
@@ -70,7 +70,7 @@ function CholBFGS(x::AbstractVector{T}) where {T}
                 similar(x, F),
                 similar(x, F),
                 similar(x, F),
-                zero(T)
+                zero(F)
                )
     return bfgs
 end

--- a/src/linesearch.jl
+++ b/src/linesearch.jl
@@ -53,7 +53,11 @@ function strong_backtracking!(fdf, x0, d, y0, grad0;
         nbracket == nbracket_max && error("Failed to find bracketing")
         # cubic interpolation (Nocedal & Wright 2nd ed., p.59)
         Δα = α - α_prev
-        Δα == 0 && error("Cannot bracket with zero step")
+
+        # return 0 signaling that bracketing failed
+        if iszero(Δα)
+            return Δα
+        end
         d1 = g_prev + g - 3 * (y - y_prev) / Δα
         det = d1^2 - g * g_prev
         if det < 0

--- a/src/linesearch.jl
+++ b/src/linesearch.jl
@@ -28,7 +28,9 @@ function strong_backtracking!(fdf, x0, d, y0, grad0;
 
     # bracketing phase
     min_factor = 17/16 # min. factor to expand bracketing interval
-    while true
+
+    nbracket_max = 200
+    for nbracket in 1:nbracket_max
         y, grad = fdf(x0, α, d)
         g = dot(grad, d)
         Δyp = (g + g0) * α / 2 # parabolic approximation
@@ -47,8 +49,11 @@ function strong_backtracking!(fdf, x0, d, y0, grad0;
             αlo, αhi, ylo, yhi, glo, ghi = α_prev, α, y_prev, y, g_prev, g
             break
         end
+
+        nbracket == nbracket_max && error("Failed to find bracketing")
         # cubic interpolation (Nocedal & Wright 2nd ed., p.59)
         Δα = α - α_prev
+        Δα == 0 && error("Cannot bracket with zero step")
         d1 = g_prev + g - 3 * (y - y_prev) / Δα
         det = d1^2 - g * g_prev
         if det < 0

--- a/src/linesearch.jl
+++ b/src/linesearch.jl
@@ -31,7 +31,13 @@ function strong_backtracking!(fdf, x0, d, y0, grad0;
     while true
         y, grad = fdf(x0, α, d)
         g = dot(grad, d)
-        if y > y0 + α * wolfe1 || y >= y_prev # x >= NaN is always false
+        Δyp = (g + g0) * α / 2 # parabolic approximation
+        if abs(Δyp) < ϵ
+            Δy = Δyp
+        else
+            Δy = y - y0
+        end
+        if Δy > α * wolfe1 || y >= y_prev + ϵ # x >= NaN is always false
             αlo, αhi, ylo, yhi, glo, ghi = α_prev, α, y_prev, y, g_prev, g
             break
         end


### PR DESCRIPTION
`DescentMethods.CholBFGS` is used by `CubicEoS.jl` so need to add this method to package. For now, I am restricted to use package's `Manifest.toml`, where `DescentMethods` comes from `chol_bfgs` branch. 